### PR TITLE
Humidity tag

### DIFF
--- a/inc/bc_hts221.h
+++ b/inc/bc_hts221.h
@@ -1,0 +1,60 @@
+#ifndef INC_BC_HTS221_H_
+#define INC_BC_HTS221_H_
+
+#include <bc_common.h>
+#include <bc_i2c.h>
+#include <bc_tick.h>
+/*
+typedef enum
+{
+    BC_HTS221_I2C_ADDRESS_DEFAULT = 0x5f,
+    BC_HTS221_I2C_ADDRESS_ALTERNATE = 0x40
+
+} bc_hts221_i2c_address_t;
+*/
+
+/*
+#define BC_TAG_HUMIDITY_DEVICE_ADDRESS_DEFAULT 0x5F
+#define BC_TAG_HUMIDITY_DEVICE_2_ADDRESS_DEFAULT 0x40
+#define BC_TAG_HUMIDITY_DEVICE_2_ADDRESS_ALTERNATE 0x41
+*/
+
+typedef enum
+{
+    BC_HTS221_EVENT_ERROR = 0,
+    BC_HTS221_EVENT_UPDATE = 1
+
+} bc_hts221_event_t;
+
+typedef enum
+{
+    BC_HTS221_STATE_ERROR = -1,
+    BC_HTS221_STATE_INITIALIZE = 0,
+    BC_HTS221_STATE_MEASURE = 1,
+    BC_HTS221_STATE_READ = 2,
+    BC_HTS221_STATE_UPDATE = 3
+
+} bc_hts221_state_t;
+
+typedef struct bc_hts221_t bc_hts221_t;
+
+struct bc_hts221_t
+{
+    bc_i2c_channel_t _i2c_channel;
+    uint8_t _i2c_address;
+    void (*_event_handler)(bc_hts221_t *, bc_hts221_event_t);
+    bc_tick_t _update_interval;
+    bc_hts221_state_t _state;
+    bool _humidity_valid;
+    int16_t _reg_humidity;
+    int16_t _h0_rh;
+    int16_t _h0_t0_out;
+    float h_grad;
+};
+
+void bc_hts221_init(bc_hts221_t *self, bc_i2c_channel_t i2c_channel, uint8_t i2c_address);
+void bc_hts221_set_event_handler(bc_hts221_t *self, void (*event_handler)(bc_hts221_t *, bc_hts221_event_t));
+void bc_hts221_set_update_interval(bc_hts221_t *self, bc_tick_t interval);
+bool bc_hts221_get_humidity_percentage(bc_hts221_t *self, float *percentage);
+
+#endif /* INC_BC_HTS221_H_ */

--- a/inc/bc_humidity_tag.h
+++ b/inc/bc_humidity_tag.h
@@ -1,7 +1,6 @@
 #ifndef _BC_HUMIDITY_TAG_H
 #define _BC_HUMIDITY_TAG_H
 
-#include <stddef.h>
 #include <bc_hdc2080.h>
 #include <bc_hts221.h>
 #include <bc_common.h>
@@ -23,10 +22,16 @@ typedef enum
 
 } bc_humidity_tag_i2c_address_t;
 
-/*
- typedef bc_hdc2080_event_t bc_humidity_tag_event_t;
- typedef bc_hdc2080_t bc_humidity_tag_t;
- */
+typedef enum
+{
+#if (BC_HTS221_EVENT_ERROR == BC_HDC2080_EVENT_ERROR)
+    BC_HUMIDITY_TAG_EVENT_ERROR = BC_HTS221_EVENT_ERROR,
+#endif
+
+#if (BC_HTS221_EVENT_UPDATE == BC_HDC2080_EVENT_UPDATE)
+    BC_HUMIDITY_TAG_EVENT_UPDATE = BC_HTS221_EVENT_UPDATE,
+#endif
+} bc_humidity_tag_event_t;
 
 typedef struct
 {
@@ -37,15 +42,6 @@ typedef struct
     } sensor;
     bc_humidity_tag_device_t device_type;
 } bc_humidity_tag_t;
-
-typedef union
-{
-    bc_hts221_event_t hts221_event;
-    bc_hdc2080_event_t hdc2080_event;
-} bc_humidity_tag_event_t;
-
-// TODO ... doporuèuju nepoužívat v HAL_I2C_Mem_Read(.....,0xFFFFFFFF),
-//              pøi velice špatném naèasování vytažení tagu se tam program zasekne forever
 
 void bc_humidity_tag_init(bc_humidity_tag_t *self, uint8_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address);
 void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t));

--- a/inc/bc_humidity_tag.h
+++ b/inc/bc_humidity_tag.h
@@ -2,41 +2,156 @@
 #define _BC_HUMIDITY_TAG_H
 
 #include <bc_hdc2080.h>
+#include <bc_hts221.h>
 
 typedef enum
 {
-    BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT = 0x40,
-    BC_HUMIDITY_TAG_I2C_ADDRESS_ALTERNATE = 0x41
+    BC_HUMIDITY_TAG_DEVICE_HTS221 = 0,
+    BC_HUMIDITY_TAG_DEVICE_HDC2080
+
+} bc_humidity_tag_device_t;
+
+typedef enum
+{
+    BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT = 0,
+    BC_HUMIDITY_TAG_I2C_ADDRESS_ALTERNATE = 1
 
 } bc_humidity_tag_i2c_address_t;
 
-typedef bc_hdc2080_event_t bc_humidity_tag_event_t;
-
-typedef bc_hdc2080_t bc_humidity_tag_t;
-
-inline void bc_humidity_tag_init(bc_humidity_tag_t *self, bc_i2c_channel_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address)
+typedef enum
 {
-    bc_hdc2080_init(self, i2c_channel, (uint8_t) i2c_address);
+    BC_HTS221_I2C_ADDRESS_DEFAULT = 0x5f,
+    BC_HTS221_I2C_ADDRESS_ALTERNATE = 0x40
+
+} bc_hts221_i2c_address_t;
+
+typedef enum
+{
+    BC_HDC2080_I2C_ADDRESS_DEFAULT = 0x40,
+    BC_HDC2080_I2C_ADDRESS_ALTERNATE = 0x41
+
+} bc_hdc2080_i2c_address_t;
+
+/*
+ typedef bc_hdc2080_event_t bc_humidity_tag_event_t;
+ typedef bc_hdc2080_t bc_humidity_tag_t;
+ */
+
+typedef struct
+{
+    union
+    {
+        bc_hts221_t hts221;
+        bc_hdc2080_t hdc2080;
+    } sensor;
+    bc_humidity_tag_device_t device_type;
+} bc_humidity_tag_t;
+
+typedef union
+{
+    bc_hts221_event_t hts221_event;
+    bc_hdc2080_event_t hdc2080_event;
+} bc_humidity_tag_event_t;
+
+// TODO ... if, else if, else ... nahradit matic9 funkc9
+
+void bc_humidity_tag_init(bc_humidity_tag_t *self, bc_i2c_channel_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address)
+{
+    // TODO ... dala by se dodìlat autodetekce, ale z toho vyplívá dost problémù ...
+
+    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
+    {
+        if(i2c_address == BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT)
+        {
+            bc_hts221_init((bc_hts221_t *)self, i2c_channel, BC_HTS221_I2C_ADDRESS_DEFAULT);
+        }
+        else
+        {
+            bc_hts221_init((bc_hts221_t *)self, i2c_channel, BC_HTS221_I2C_ADDRESS_ALTERNATE);
+        }
+    }
+    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
+    {
+        if(i2c_address == BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT)
+        {
+            bc_hdc2080_init((bc_hdc2080_t *)self, i2c_channel, BC_HDC2080_I2C_ADDRESS_DEFAULT);
+        }
+        else
+        {
+            bc_hdc2080_init((bc_hdc2080_t *)self, i2c_channel, BC_HDC2080_I2C_ADDRESS_ALTERNATE);
+        }
+    }
+    else
+    {
+        for (;;);
+    }
 }
 
-inline void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t))
+void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t))
 {
-    bc_hdc2080_set_event_handler(self, event_handler);
+    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
+    {
+        bc_hts221_set_event_handler((bc_hts221_t *) &self->sensor, (void (*)(bc_hts221_t *, bc_hts221_event_t)) event_handler);
+    }
+    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
+    {
+        bc_hdc2080_set_event_handler((bc_hdc2080_t *) &self->sensor, (void (*)(bc_hdc2080_t *, bc_hdc2080_event_t)) event_handler);
+    }
+    else
+    {
+        for (;;);
+    }
 }
 
-inline void bc_humidity_tag_set_update_interval(bc_humidity_tag_t *self, bc_tick_t interval)
+void bc_humidity_tag_set_update_interval(bc_humidity_tag_t *self, bc_tick_t interval)
 {
-    bc_hdc2080_set_update_interval(self, interval);
+    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
+    {
+        bc_hts221_set_update_interval((bc_hts221_t *) &self->sensor, interval);
+    }
+    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
+    {
+        bc_hdc2080_set_update_interval((bc_hdc2080_t *) &self->sensor, interval);
+    }
+    else
+    {
+        for (;;);
+    }
 }
 
-inline bool bc_humidity_tag_get_humidity_raw(bc_humidity_tag_t *self, uint16_t *raw)
+bool bc_humidity_tag_get_humidity_raw(bc_humidity_tag_t *self, uint16_t *raw)
 {
-    return bc_hdc2080_get_humidity_raw(self, raw);
+    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
+    {
+        return false;
+        // TODO ... not implemented
+        // return bc_hts221_get_humidity_raw((bc_hts221_t *) &self->device, raw);
+    }
+    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
+    {
+        return bc_hdc2080_get_humidity_raw((bc_hdc2080_t *) &self->sensor, raw);
+    }
+    else
+    {
+        for (;;);
+    }
 }
 
-inline bool bc_humidity_tag_get_humidity_percentage(bc_humidity_tag_t *self, float *percentage)
+bool bc_humidity_tag_get_humidity_percentage(bc_humidity_tag_t *self, float *percentage)
 {
-    return bc_hdc2080_get_humidity_percentage(self, percentage);
+    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
+    {
+        return bc_hts221_get_humidity_percentage((bc_hts221_t *) &self->sensor, percentage);
+    }
+    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
+    {
+        return bc_hdc2080_get_humidity_percentage((bc_hdc2080_t *) &self->sensor, percentage);
+    }
+    else
+    {
+        for (;;)
+            ;
+    }
 }
 
 #endif // _BC_HUMIDITY_TAG_H

--- a/inc/bc_humidity_tag.h
+++ b/inc/bc_humidity_tag.h
@@ -1,36 +1,27 @@
 #ifndef _BC_HUMIDITY_TAG_H
 #define _BC_HUMIDITY_TAG_H
 
+#include <stddef.h>
 #include <bc_hdc2080.h>
 #include <bc_hts221.h>
+#include <bc_common.h>
+#include <bc_tick.h>
 
 typedef enum
 {
     BC_HUMIDITY_TAG_DEVICE_HTS221 = 0,
-    BC_HUMIDITY_TAG_DEVICE_HDC2080
+    BC_HUMIDITY_TAG_DEVICE_HDC2080,
+    BC_HUMIDITY_TAG_DEVICE_COUNT
 
 } bc_humidity_tag_device_t;
 
 typedef enum
 {
     BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT = 0,
-    BC_HUMIDITY_TAG_I2C_ADDRESS_ALTERNATE = 1
+    BC_HUMIDITY_TAG_I2C_ADDRESS_ALTERNATE,
+    BC_HUMIDITY_TAG_I2C_ADDRESS_COUNT
 
 } bc_humidity_tag_i2c_address_t;
-
-typedef enum
-{
-    BC_HTS221_I2C_ADDRESS_DEFAULT = 0x5f,
-    BC_HTS221_I2C_ADDRESS_ALTERNATE = 0x40
-
-} bc_hts221_i2c_address_t;
-
-typedef enum
-{
-    BC_HDC2080_I2C_ADDRESS_DEFAULT = 0x40,
-    BC_HDC2080_I2C_ADDRESS_ALTERNATE = 0x41
-
-} bc_hdc2080_i2c_address_t;
 
 /*
  typedef bc_hdc2080_event_t bc_humidity_tag_event_t;
@@ -53,105 +44,13 @@ typedef union
     bc_hdc2080_event_t hdc2080_event;
 } bc_humidity_tag_event_t;
 
-// TODO ... if, else if, else ... nahradit matic9 funkc9
+// TODO ... doporuèuju nepoužívat v HAL_I2C_Mem_Read(.....,0xFFFFFFFF),
+//              pøi velice špatném naèasování vytažení tagu se tam program zasekne forever
 
-void bc_humidity_tag_init(bc_humidity_tag_t *self, bc_i2c_channel_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address)
-{
-    // TODO ... dala by se dodìlat autodetekce, ale z toho vyplívá dost problémù ...
-
-    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
-    {
-        if(i2c_address == BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT)
-        {
-            bc_hts221_init((bc_hts221_t *)self, i2c_channel, BC_HTS221_I2C_ADDRESS_DEFAULT);
-        }
-        else
-        {
-            bc_hts221_init((bc_hts221_t *)self, i2c_channel, BC_HTS221_I2C_ADDRESS_ALTERNATE);
-        }
-    }
-    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
-    {
-        if(i2c_address == BC_HUMIDITY_TAG_I2C_ADDRESS_DEFAULT)
-        {
-            bc_hdc2080_init((bc_hdc2080_t *)self, i2c_channel, BC_HDC2080_I2C_ADDRESS_DEFAULT);
-        }
-        else
-        {
-            bc_hdc2080_init((bc_hdc2080_t *)self, i2c_channel, BC_HDC2080_I2C_ADDRESS_ALTERNATE);
-        }
-    }
-    else
-    {
-        for (;;);
-    }
-}
-
-void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t))
-{
-    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
-    {
-        bc_hts221_set_event_handler((bc_hts221_t *) &self->sensor, (void (*)(bc_hts221_t *, bc_hts221_event_t)) event_handler);
-    }
-    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
-    {
-        bc_hdc2080_set_event_handler((bc_hdc2080_t *) &self->sensor, (void (*)(bc_hdc2080_t *, bc_hdc2080_event_t)) event_handler);
-    }
-    else
-    {
-        for (;;);
-    }
-}
-
-void bc_humidity_tag_set_update_interval(bc_humidity_tag_t *self, bc_tick_t interval)
-{
-    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
-    {
-        bc_hts221_set_update_interval((bc_hts221_t *) &self->sensor, interval);
-    }
-    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
-    {
-        bc_hdc2080_set_update_interval((bc_hdc2080_t *) &self->sensor, interval);
-    }
-    else
-    {
-        for (;;);
-    }
-}
-
-bool bc_humidity_tag_get_humidity_raw(bc_humidity_tag_t *self, uint16_t *raw)
-{
-    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
-    {
-        return false;
-        // TODO ... not implemented
-        // return bc_hts221_get_humidity_raw((bc_hts221_t *) &self->device, raw);
-    }
-    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
-    {
-        return bc_hdc2080_get_humidity_raw((bc_hdc2080_t *) &self->sensor, raw);
-    }
-    else
-    {
-        for (;;);
-    }
-}
-
-bool bc_humidity_tag_get_humidity_percentage(bc_humidity_tag_t *self, float *percentage)
-{
-    if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HTS221)
-    {
-        return bc_hts221_get_humidity_percentage((bc_hts221_t *) &self->sensor, percentage);
-    }
-    else if (self->device_type == BC_HUMIDITY_TAG_DEVICE_HDC2080)
-    {
-        return bc_hdc2080_get_humidity_percentage((bc_hdc2080_t *) &self->sensor, percentage);
-    }
-    else
-    {
-        for (;;)
-            ;
-    }
-}
+void bc_humidity_tag_init(bc_humidity_tag_t *self, uint8_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address);
+void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t));
+void bc_humidity_tag_set_update_interval(bc_humidity_tag_t *self, bc_tick_t interval);
+bool bc_humidity_tag_get_humidity_raw(bc_humidity_tag_t *self, uint16_t *raw);
+bool bc_humidity_tag_get_humidity_percentage(bc_humidity_tag_t *self, float *percentage);
 
 #endif // _BC_HUMIDITY_TAG_H

--- a/src/bc_hts221.c
+++ b/src/bc_hts221.c
@@ -1,0 +1,289 @@
+#include <bc_hts221.h>
+#include <bc_scheduler.h>
+
+#define HTS221_WHO_AM_I 0x0F
+#define HTS221_WHO_AM_I_RESULT 0xBC
+#define HTS221_AV_CONF 0x10
+#define HTS221_CTRL_REG1 0x20
+#define HTS221_CTRL_REG2 0x21
+#define HTS221_CTRL_REG3 0x22
+#define HTS221_STATUS_REG 0x27
+#define HTS221_HUMIDITY_OUT_L 0x28
+#define HTS221_HUMIDITY_OUT_H 0x29
+#define HTS221_TEMP_OUT_L 0x2A
+#define HTS221_TEMP_OUT_H 0x2B
+#define HTS221_CALIB_OFFSET 0x30
+#define HTS221_CALIB_0 0x30
+#define HTS221_CALIB_1 0x31
+#define HTS221_CALIB_2 0x32
+#define HTS221_CALIB_3 0x33
+#define HTS221_CALIB_4 0x34
+#define HTS221_CALIB_5 0x35
+#define HTS221_CALIB_6 0x36
+#define HTS221_CALIB_7 0x37
+#define HTS221_CALIB_8 0x38
+#define HTS221_CALIB_9 0x39
+#define HTS221_CALIB_A 0x3A
+#define HTS221_CALIB_B 0x3B
+#define HTS221_CALIB_C 0x3C
+#define HTS221_CALIB_D 0x3D
+#define HTS221_CALIB_E 0x3E
+#define HTS221_CALIB_F 0x3F
+
+#define HTS221_BIT_PD       0x80
+#define HTS221_BIT_BDU      0x04
+
+#define HTS221_BIT_ONE_SHOT 0x01
+#define HTS221_BIT_T_DA     0x01
+#define HTS221_BIT_H_DA     0x02
+
+#define HTS221_MASK_ODR     0x03
+#define HTS221_ODR_ONE_SHOT 0x00
+#define HTS221_ODR_1hz      0x01
+#define HTS221_ODR_7hz      0x02
+#define HTS221_ODR_12hz     0x03
+
+// TODO Clarify timing with TI
+#define BC_HTS221_DELAY_RUN 50
+#define BC_HTS221_DELAY_INITIALIZATION 50
+#define BC_HTS221_DELAY_MEASUREMENT 50
+
+static bc_tick_t _bc_hts221_task(void *param);
+static bool _bc_hts221_load_calibration(bc_hts221_t *self);
+
+void bc_hts221_init(bc_hts221_t *self, bc_i2c_channel_t i2c_channel, uint8_t i2c_address)
+{
+    memset(self, 0, sizeof(*self));
+
+    self->_i2c_channel = i2c_channel;
+    self->_i2c_address = i2c_address;
+
+    _bc_hts221_load_calibration(self);
+
+    bc_scheduler_register(_bc_hts221_task, self, BC_HTS221_DELAY_RUN);
+}
+
+bool bc_hts221_echo(bc_i2c_channel_t i2c_channel, uint8_t i2c_address)
+{
+    uint8_t result;
+
+    bc_i2c_read_8b(i2c_channel, i2c_address, HTS221_WHO_AM_I, &result);
+    if(result == HTS221_WHO_AM_I_RESULT)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool _bc_hts221_load_calibration(bc_hts221_t *self)
+{
+    uint8_t i;
+    uint8_t calibration[16];
+    int16_t h1_rh;
+    int16_t h1_t0_out;
+
+
+    for (i = 0; i < 16; i++)
+    {
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_CALIB_OFFSET + i, &calibration[i]))
+        {
+            return false;
+        }
+    }
+
+    self->_h0_rh = (int16_t) calibration[0];
+    self->_h0_rh >>= 1;
+    h1_rh = (int16_t) calibration[1];
+    h1_rh >>= 1;
+
+    self->_h0_t0_out = (int16_t) calibration[6];
+    self->_h0_t0_out |= ((int16_t) calibration[7]) << 8;
+
+    h1_t0_out = (int16_t) calibration[10];
+    h1_t0_out |= ((int16_t) calibration[11]) << 8;
+
+    if ((h1_t0_out - self->_h0_t0_out) == 0)
+    {
+        return false;
+    }
+
+    self->h_grad = (float) (h1_rh - self->_h0_rh) / (float) (h1_t0_out - self->_h0_t0_out);
+
+    uint16_t t0_degC = (int16_t) calibration[2];
+    t0_degC |= (int16_t) (0x03 & calibration[5]) << 8;
+    t0_degC >>= 3; // /= 8.0
+
+    uint16_t t1_degC = (int16_t) calibration[3];
+    t1_degC |= (int16_t) (0x0C & calibration[5]) << 6;
+    t1_degC >>= 3;
+
+    return true;
+}
+
+void bc_hts221_set_event_handler(bc_hts221_t *self, void (*event_handler)(bc_hts221_t *, bc_hts221_event_t))
+{
+    self->_event_handler = event_handler;
+}
+
+void bc_hts221_set_update_interval(bc_hts221_t *self, bc_tick_t interval)
+{
+    self->_update_interval = interval;
+}
+
+bool bc_hts221_get_humidity_percentage(bc_hts221_t *self, float *percentage)
+{
+    *percentage = self->_h0_rh + ((self->_reg_humidity - self->_h0_t0_out) * self->h_grad);
+
+    if (*percentage >= 100.f)
+    {
+        *percentage = 100.f;
+    }
+
+    return true;
+}
+
+static bc_tick_t _bc_hts221_task(void *param)
+{
+    bc_hts221_t *self = param;
+
+    start:
+
+    switch (self->_state)
+    {
+    case BC_HTS221_STATE_ERROR:
+    {
+        self->_humidity_valid = false;
+
+        if (self->_event_handler != NULL)
+        {
+            self->_event_handler(self, BC_HTS221_EVENT_ERROR);
+        }
+
+        self->_state = BC_HTS221_STATE_INITIALIZE;
+
+        return self->_update_interval;
+    }
+    case BC_HTS221_STATE_INITIALIZE:
+    {
+        uint8_t ctrl_reg1;
+
+        self->_state = BC_HTS221_STATE_ERROR;
+
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, &ctrl_reg1))
+        {
+            goto start;
+        }
+
+        ctrl_reg1 &= ~HTS221_BIT_PD;
+
+        if (!bc_i2c_write_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, ctrl_reg1))
+        {
+            goto start;
+        }
+
+        self->_state = BC_HTS221_STATE_MEASURE;
+
+        return BC_HTS221_DELAY_INITIALIZATION;
+    }
+    case BC_HTS221_STATE_MEASURE:
+    {
+        uint8_t ctrl_reg1;
+        self->_state = BC_HTS221_STATE_ERROR;
+
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, &ctrl_reg1))
+        {
+            goto start;
+        }
+
+        ctrl_reg1 |= HTS221_BIT_PD;
+
+        if (!bc_i2c_write_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, ctrl_reg1))
+        {
+            goto start;
+        }
+
+        if (!bc_i2c_write_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, HTS221_BIT_PD | HTS221_BIT_BDU))
+        {
+            goto start;
+        }
+
+        if (!bc_i2c_write_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG2, HTS221_BIT_ONE_SHOT))
+        {
+            goto start;
+        }
+
+        self->_state = BC_HTS221_STATE_READ;
+
+        return BC_HTS221_DELAY_MEASUREMENT;
+    }
+    case BC_HTS221_STATE_READ:
+    {
+        self->_state = BC_HTS221_STATE_ERROR;
+
+        uint8_t reg_status;
+        uint8_t retval[2];
+        uint8_t ctrl_reg1;
+
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_STATUS_REG, &reg_status))
+        {
+            goto start;
+        }
+
+        if ((reg_status & HTS221_BIT_H_DA) == 0)
+        {
+            goto start;
+        }
+
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_HUMIDITY_OUT_H, &retval[1]))
+        {
+            goto start;
+        }
+
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_HUMIDITY_OUT_L, &retval[0]))
+        {
+            goto start;
+        }
+
+        self->_reg_humidity = ((uint16_t)retval[1] << 8) | retval[0];
+
+        /* Power-down */
+        if (!bc_i2c_read_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, &ctrl_reg1))
+        {
+            goto start;
+        }
+
+        ctrl_reg1 &= ~HTS221_BIT_PD;
+
+        if (!bc_i2c_write_8b(self->_i2c_channel, self->_i2c_address, HTS221_CTRL_REG1, ctrl_reg1))
+        {
+            goto start;
+        }
+
+        self->_humidity_valid = true;
+
+        self->_state = BC_HTS221_STATE_UPDATE;
+
+        goto start;
+    }
+    case BC_HTS221_STATE_UPDATE:
+    {
+        if (self->_event_handler != NULL)
+        {
+            self->_event_handler(self, BC_HTS221_EVENT_UPDATE);
+        }
+
+        self->_state = BC_HTS221_STATE_MEASURE;
+
+        return self->_update_interval;
+    }
+    default:
+    {
+        self->_state = BC_HTS221_STATE_ERROR;
+
+        goto start;
+    }
+    }
+}

--- a/src/bc_humidity_tag.c
+++ b/src/bc_humidity_tag.c
@@ -46,9 +46,10 @@ static const uint32_t fcn_table[BC_HUMIDITY_TAG_DEVICE_COUNT][_BC_HUMIDITY_TAG_F
     [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hts221_get_humidity_percentage,
     [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hdc2080_get_humidity_percentage,
 
+#if 0
     [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_VALIDITY] = (const uint32_t)&bc_hts221_get_humidity_percentage,
     [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_VALIDITY] = (const uint32_t)&bc_hdc2080_get_humidity_percentage,
-
+#endif
 };
 
 #define _BC_HUMIDITY_TAG_INIT(_SELF_, _I2C_CHANNEL_, _I2C_ADDRESS_) (((void (*)(bc_humidity_tag_t *, uint8_t, uint8_t)) fcn_table[self->device_type][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER])((void *)&_SELF_->sensor, _I2C_CHANNEL_, _I2C_ADDRESS_))

--- a/src/bc_humidity_tag.c
+++ b/src/bc_humidity_tag.c
@@ -7,6 +7,7 @@ typedef enum
     _BC_HUMIDITY_TAG_FUNCTION_SET_UPDATE_INTERVAL,
     _BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_RAW,
     _BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE,
+    _BC_HUMIDITY_TAG_FUNCTION_GET_VALIDITY,
     _BC_HUMIDITY_TAG_FUNCTION_COUNT
 } _bc_humidity_tag_function_t;
 
@@ -44,6 +45,10 @@ static const uint32_t fcn_table[BC_HUMIDITY_TAG_DEVICE_COUNT][_BC_HUMIDITY_TAG_F
 
     [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hts221_get_humidity_percentage,
     [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hdc2080_get_humidity_percentage,
+
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_VALIDITY] = (const uint32_t)&bc_hts221_get_humidity_percentage,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_VALIDITY] = (const uint32_t)&bc_hdc2080_get_humidity_percentage,
+
 };
 
 #define _BC_HUMIDITY_TAG_INIT(_SELF_, _I2C_CHANNEL_, _I2C_ADDRESS_) (((void (*)(bc_humidity_tag_t *, uint8_t, uint8_t)) fcn_table[self->device_type][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER])((void *)&_SELF_->sensor, _I2C_CHANNEL_, _I2C_ADDRESS_))

--- a/src/bc_humidity_tag.c
+++ b/src/bc_humidity_tag.c
@@ -1,0 +1,83 @@
+#include <bc_humidity_tag.h>
+
+typedef enum
+{
+    _BC_HUMIDITY_TAG_FUNCTION_INIT = 0,
+    _BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER,
+    _BC_HUMIDITY_TAG_FUNCTION_SET_UPDATE_INTERVAL,
+    _BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_RAW,
+    _BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE,
+    _BC_HUMIDITY_TAG_FUNCTION_COUNT
+} _bc_humidity_tag_function_t;
+
+typedef enum
+{
+    BC_HTS221_I2C_ADDRESS_DEFAULT = 0x5f,
+    BC_HTS221_I2C_ADDRESS_ALTERNATE = 0x40
+
+} bc_hts221_i2c_address_t;
+
+typedef enum
+{
+    BC_HDC2080_I2C_ADDRESS_DEFAULT = 0x40,
+    BC_HDC2080_I2C_ADDRESS_ALTERNATE = 0x41
+
+} bc_hdc2080_i2c_address_t;
+
+__attribute__((weak)) bool bc_hts221_get_humidity_raw(bc_hts221_t *self, uint16_t *raw);
+
+/* Dirty, another way have to be found, */
+/* but iso c forbids conversion of function pointer to object pointer type */
+static const uint32_t fcn_table[BC_HUMIDITY_TAG_DEVICE_COUNT][_BC_HUMIDITY_TAG_FUNCTION_COUNT] =
+{
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_INIT] = (const uint32_t)&bc_hts221_init,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_INIT] = (const uint32_t)&bc_hdc2080_init,
+
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER] = (const uint32_t)&bc_hts221_set_event_handler,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER] = (const uint32_t)&bc_hdc2080_set_event_handler,
+
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_SET_UPDATE_INTERVAL] = (const uint32_t)&bc_hts221_set_update_interval,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_SET_UPDATE_INTERVAL] = (const uint32_t)&bc_hdc2080_set_update_interval,
+
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_RAW] = (const uint32_t)&bc_hts221_get_humidity_raw,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_RAW] = (const uint32_t)&bc_hdc2080_get_humidity_raw,
+
+    [BC_HUMIDITY_TAG_DEVICE_HTS221][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hts221_get_humidity_percentage,
+    [BC_HUMIDITY_TAG_DEVICE_HDC2080][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE] = (const uint32_t)&bc_hdc2080_get_humidity_percentage,
+};
+
+#define _BC_HUMIDITY_TAG_INIT(_SELF_, _I2C_CHANNEL_, _I2C_ADDRESS_) (((void (*)(bc_humidity_tag_t *, uint8_t, uint8_t)) fcn_table[self->device_type][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER])((void *)&_SELF_->sensor, _I2C_CHANNEL_, _I2C_ADDRESS_))
+#define _BC_HUMIDITY_TAG_SET_EVENT_HANDLER(_SELF_, _EVENT_HANDLER_) (((void (*)(bc_humidity_tag_t *, uint32_t)) fcn_table[_SELF_->device_type][_BC_HUMIDITY_TAG_FUNCTION_SET_EVENT_HANDLER])((void *)&_SELF_->sensor, (uint32_t)_EVENT_HANDLER_))
+#define _BC_HUMIDITY_TAG_SET_UPDATE_INTERVAL(_SELF_, _INTERVAL_) (((void (*)(bc_humidity_tag_t *, bc_tick_t)) fcn_table[_SELF_->device_type][_BC_HUMIDITY_TAG_FUNCTION_SET_UPDATE_INTERVAL])((void *)&_SELF_->sensor, _INTERVAL_))
+#define _BC_HUMIDITY_TAG_GET_HUMIDITY_RAW(_SELF_, _P_RAW_) (((bool (*)(bc_humidity_tag_t *, uint16_t *)) fcn_table[_SELF_->device_type][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_RAW])((void *)&_SELF_->sensor, _P_RAW_))
+#define _BC_HUMIDITY_TAG_GET_HUMIDITY_PERCENTAGE(_SELF_, _P_PERCENTAGE_) (((bool (*)(bc_humidity_tag_t *, float *)) fcn_table[_SELF_->device_type][_BC_HUMIDITY_TAG_FUNCTION_GET_HUMIDITY_PERCENTAGE])((void *)&_SELF_->sensor, _P_PERCENTAGE_))
+
+void bc_humidity_tag_init(bc_humidity_tag_t *self, uint8_t i2c_channel, bc_humidity_tag_i2c_address_t i2c_address)
+{
+    _BC_HUMIDITY_TAG_INIT(self, i2c_channel, i2c_address);
+}
+
+void bc_humidity_tag_set_event_handler(bc_humidity_tag_t *self, void (*event_handler)(bc_humidity_tag_t *, bc_humidity_tag_event_t))
+{
+    _BC_HUMIDITY_TAG_SET_EVENT_HANDLER(self, event_handler);
+}
+
+void bc_humidity_tag_set_update_interval(bc_humidity_tag_t *self, bc_tick_t interval)
+{
+    _BC_HUMIDITY_TAG_SET_UPDATE_INTERVAL(self, interval);
+}
+
+bool bc_humidity_tag_get_humidity_raw(bc_humidity_tag_t *self, uint16_t *raw)
+{
+    return _BC_HUMIDITY_TAG_GET_HUMIDITY_RAW(self, raw);
+}
+
+bool bc_humidity_tag_get_humidity_percentage(bc_humidity_tag_t *self, float *percentage)
+{
+    return _BC_HUMIDITY_TAG_GET_HUMIDITY_PERCENTAGE(self, percentage);
+}
+
+__attribute__((weak)) bool bc_hts221_get_humidity_raw(bc_hts221_t *self, uint16_t *raw)
+{
+    return false;
+}


### PR DESCRIPTION
Zatím neotestováno, ale vše co se týká pseudo-wrapperu by mělo být ok. Doporučil bych nepoužívat ve funkcích typu HAL_I2C_Mem_...() timeout 0xFFFFFFFF, při špatně načasovaném vytažení tagu se tam program zasekne.